### PR TITLE
SP-888 Fjerne unødvendig avhengighet i idporten-actuator-starter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,10 +44,6 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-validation</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/no/idporten/actuator/config/HealthCheckEndpointProperties.java
+++ b/src/main/java/no/idporten/actuator/config/HealthCheckEndpointProperties.java
@@ -2,18 +2,15 @@ package no.idporten.actuator.config;
 
 import no.idporten.actuator.monitor.HealthCheckEndpoint;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.validation.annotation.Validated;
 
-import jakarta.validation.Valid;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 
-@Validated
 @ConfigurationProperties(prefix = "external-dependency-health-checks")
 public class HealthCheckEndpointProperties implements Serializable {
-    private Map<String, @Valid HealthCheckEndpoint> healthEndpoints;
+    private Map<String, HealthCheckEndpoint> healthEndpoints;
 
     public HealthCheckEndpointProperties(Map<String, HealthCheckEndpoint> healthEndpoints) {
         this.setHealthEndpoints(healthEndpoints);

--- a/src/main/java/no/idporten/actuator/monitor/HealthCheckEndpoint.java
+++ b/src/main/java/no/idporten/actuator/monitor/HealthCheckEndpoint.java
@@ -1,19 +1,23 @@
 package no.idporten.actuator.monitor;
 
-import jakarta.validation.constraints.NotNull;
 import java.io.Serializable;
+import java.util.Objects;
 
-public record HealthCheckEndpoint(@NotNull
+public record HealthCheckEndpoint(
                                   String name,
-                                  @NotNull
                                   String baseUri,
-                                  @NotNull
                                   String endpoint,
                                   long connectTimeoutMs,
                                   long readTimeoutMs,
                                   //the status that will be set if the endpoint returns anything other than UP or DEGRADED
                                   String mapDownStatusTo)
         implements Serializable {
+
+    public HealthCheckEndpoint {
+        Objects.requireNonNull(name, "name must not be null");
+        Objects.requireNonNull(baseUri, "baseUri must not be null");
+        Objects.requireNonNull(endpoint, "endpoint must not be null");
+    }
 
     public long connectTimeoutMs() {
         return this.connectTimeoutMs != -1 ? this.connectTimeoutMs : 2000;


### PR DESCRIPTION
Vi oppdaget en litt unødvendig avhengighet til validation-api når vi dro inn denne starteren i et lite og enkelt prosjekt.
Lager en PR for å ta vekk avhengigheten